### PR TITLE
Link to "new" discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Questions That Belong to the Mailing List
 
 Questions, discussions, investigations or issues that lack information needed to investigate them
-are moved to this repository.
+are moved to the [discussions site](https://github.com/rabbitmq/rabbitmq-server/discussions/).
 
 Please use RabbitMQ [mailing list](https://groups.google.com/forum/#!forum/rabbitmq-users) for questions.


### PR DESCRIPTION
Sometimes my favorite search engines sends me to this old page. This should help.